### PR TITLE
Feature request: make X86 compiler get path to runtime.o from RC_RUNTIME env variable

### DIFF
--- a/regression/Makefile
+++ b/regression/Makefile
@@ -6,8 +6,8 @@ INTERPRETER_TESTS=test011
 check: $(TESTS) $(INTERPRETER_TESTS) 
 
 $(TESTS): %: %.expr
-	../rc.native     $< && cat $@.input | ./$@ > $@.log && diff $@.log orig/$@.log
-	../rc.native -so $< && cat $@.input | ./$@ > $@.log && diff $@.log orig/$@.log
+	RC_RUNTIME=../runtime ../rc.native     $< && cat $@.input | ./$@ > $@.log && diff $@.log orig/$@.log
+	RC_RUNTIME=../runtime ../rc.native -so $< && cat $@.input | ./$@ > $@.log && diff $@.log orig/$@.log
 	cat $@.input | ../rc.native -i $< > $@.log && diff $@.log orig/$@.log
 	cat $@.input | ../rc.native -s $< > $@.log && diff $@.log orig/$@.log
 

--- a/src/X86.ml
+++ b/src/X86.ml
@@ -157,4 +157,4 @@ let build stmt name =
   let outf = open_out (Printf.sprintf "%s.s" name) in
   Printf.fprintf outf "%s" (compile stmt);
   close_out outf;
-  ignore (Sys.command (Printf.sprintf "gcc -m32 -o %s ../runtime/runtime.o %s.s" name name))
+  ignore (Sys.command (Printf.sprintf "gcc -m32 -o %s $RC_RUNTIME/runtime.o %s.s" name name))


### PR DESCRIPTION
Этот PR конфликтует с #48 и #49 
