### PR TITLE
Sort test files in makfiles in regressions/expressions and regressions/deep-expressions

### DIFF
--- a/regression/deep-expressions/Makefile
+++ b/regression/deep-expressions/Makefile
@@ -1,4 +1,4 @@
-TESTS=$(basename $(wildcard generated*.expr))
+TESTS=$(basename $(sort $(wildcard generated*.expr)))
 
 .PHONY: check $(TESTS)
 

--- a/regression/expressions/Makefile
+++ b/regression/expressions/Makefile
@@ -1,4 +1,4 @@
-TESTS=$(basename $(wildcard generated*.expr))
+TESTS=$(basename $(sort $(wildcard generated*.expr)))
 
 .PHONY: check $(TESTS)
 


### PR DESCRIPTION
Otherwise order of tests execution is pretty random which makes debugging harder.